### PR TITLE
Added Test Adapter for easy test access in VS

### DIFF
--- a/CertiPay.Common.Testing/CertiPay.Common.Testing.csproj
+++ b/CertiPay.Common.Testing/CertiPay.Common.Testing.csproj
@@ -50,6 +50,10 @@
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit3TestAdapter.3.2.0\lib\Mono.Cecil.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
@@ -58,9 +62,21 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="nunit.engine, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit3TestAdapter.3.2.0\lib\nunit.engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit3TestAdapter.3.2.0\lib\nunit.engine.api.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="NUnit3.TestAdapter, Version=3.2.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit3TestAdapter.3.2.0\lib\NUnit3.TestAdapter.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.31.3.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoFixture.3.31.3\lib\net40\Ploeh.AutoFixture.dll</HintPath>

--- a/CertiPay.Common.Testing/CertiPay.Common.Testing.nuspec
+++ b/CertiPay.Common.Testing/CertiPay.Common.Testing.nuspec
@@ -12,6 +12,7 @@
     <owners>Matt Wagner</owners>
     <dependencies>
       <dependency id="NUnit" version="3.2.1" />
+      <dependency id="NUnit3TestAdapter" version="3.2.0" />
       <dependency id="Moq" version="4.2.1507.0118" />
       <dependency id="AutoFixture" version="3.31.3" />
       <dependency id="ApprovalTests" version="3.0.9" />

--- a/CertiPay.Common.Testing/packages.config
+++ b/CertiPay.Common.Testing/packages.config
@@ -13,4 +13,5 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.2.1" targetFramework="net451" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.2.1" targetFramework="net451" />
   <package id="NUnit.Runners" version="3.2.1" targetFramework="net451" />
+  <package id="NUnit3TestAdapter" version="3.2.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
This will allow any project that is using CertiPay.Common.Testing to easily access the test cases in the Visual Studio Test Explorer