### PR TITLE
Use UTF8 explicitly

### DIFF
--- a/CertiPay.Common.Notifications/Notifications/ServiceSender.cs
+++ b/CertiPay.Common.Notifications/Notifications/ServiceSender.cs
@@ -105,7 +105,7 @@ namespace CertiPay.Notifications
         {
             var json = Serializer.Serialize(t);
 
-            var content = new StringContent(json, Encoding.Default, "application/json");
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
 
             await GetClient().PostAsync(resource, content, token);
         }


### PR DESCRIPTION
Emails being delivered through NotificationSender were occasionally having additional characters injected in the body content.  The source did not have these so it must be downstream.

It looks like an encoding issue related to the serialization as it's wrong in the datastore as well.

![image](https://user-images.githubusercontent.com/1588329/65099239-75ba2a00-d995-11e9-88e9-80cfda6ce7fa.png)
